### PR TITLE
Remove matrix stack :(

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required (VERSION 2.6)
 project (Engine)
 
 set(engine_source_files
+  GameObject.cpp
   Transform.cpp
   VisibleObject.cpp
   Game.cpp

--- a/src/GLManager.cpp
+++ b/src/GLManager.cpp
@@ -19,8 +19,6 @@ GLManager::GLManager(int width, int height)
   glViewport(0, 0, width, height);
 
   createShaders();
-
-  transformStack.push(glm::mat4(1));
 }
 
 GLManager::~GLManager(void)
@@ -39,31 +37,7 @@ void GLManager::renderScene(SceneNode *scene)
 
   glUniformMatrix4fv(shader1->getUniformLocation("ViewProj"), 1, GL_FALSE, &viewProj[0][0]);
 
-  recursiveSceneRenderer(scene);
-}
-
-void GLManager::recursiveSceneRenderer(SceneNode *scene)
-{
-  // compute current transform
-  glm::mat4 currentTransform = transformStack.top() * scene->getTransform().getTransformMatrix();
-
-  // push scene transform matrix to stack
-  transformStack.push(currentTransform);
-
-  // set shader to transform to current location.
-  glUniformMatrix4fv(shader1->getUniformLocation("Model"), 1, GL_FALSE, &currentTransform[0][0]);
-
-  // render this current scene
-  scene->render(shader1);
-
-  // recursive render children with this function
-  for (unsigned int i = 0; i < scene->getChildren()->size(); i++)
-  {
-    recursiveSceneRenderer(scene->getChildren()->at(i));
-  }
-
-  // pop scene transform
-  transformStack.pop();
+  scene->renderAll(shader1);
 }
 
 void GLManager::createShaders(void)

--- a/src/GLManager.h
+++ b/src/GLManager.h
@@ -4,8 +4,6 @@
 #include <glm/glm.hpp>
 #include <GL/glew.h>
 
-#include <stack>
-
 #include "Shader.h"
 #include "SceneNode.h"
 #include "Transform.h"
@@ -20,14 +18,11 @@ public:
   void setViewProjection(const glm::mat4& viewProj);
 
 private:
-  void recursiveSceneRenderer(SceneNode *scene);
   void createShaders(void);
 
   Shader *shader1;
 
   glm::mat4 viewProj;
-
-  std::stack<glm::mat4> transformStack;
 };
 
 #endif

--- a/src/GameObject.cpp
+++ b/src/GameObject.cpp
@@ -1,0 +1,6 @@
+#include "GameObject.h"
+
+void GameObject::setParent(SceneNode *parentNode)
+{
+  this->parentNode = parentNode;
+}

--- a/src/GameObject.h
+++ b/src/GameObject.h
@@ -2,6 +2,7 @@
 #define GAME_OBJECT_H
 
 #include "Shader.h"
+#include "SceneNode.h"
 
 class GameObject
 {
@@ -10,6 +11,11 @@ public:
 
   virtual void update(int delta) = 0;
   virtual void render(Shader *shader) {};
+
+  void setParent(SceneNode *parentNode);
+
+protected:
+  SceneNode *parentNode;
 };
 
 #endif

--- a/src/SceneNode.cpp
+++ b/src/SceneNode.cpp
@@ -1,5 +1,7 @@
 #include "SceneNode.h"
 
+#include "GameObject.h"
+
 SceneNode::SceneNode(void)
 {
   parentNode = NULL;
@@ -26,11 +28,18 @@ void SceneNode::addChild(SceneNode* child)
 
 void SceneNode::addObject(GameObject* object)
 {
+  object->setParent(this);
   gameObjects.push_back(object);
 }
 
 void SceneNode::updateAll(int delta)
 {
+  if (parentNode == NULL) {
+    worldMatrix = transform.getTransformMatrix();
+  } else {
+    worldMatrix = parentNode->worldMatrix * transform.getTransformMatrix();
+  }
+
   for (unsigned int i = 0; i < gameObjects.size(); i++)
   {
     gameObjects[i]->update(delta);
@@ -39,14 +48,6 @@ void SceneNode::updateAll(int delta)
   for (unsigned int i = 0; i < children.size(); i++)
   {
     children[i]->updateAll(delta);
-  }
-}
-
-void SceneNode::render(Shader *shader)
-{
-  for (unsigned int i = 0; i < gameObjects.size(); i++)
-  {
-    gameObjects[i]->render(shader);
   }
 }
 
@@ -71,4 +72,9 @@ Transform& SceneNode::getTransform(void)
 std::vector<SceneNode*> *SceneNode::getChildren(void)
 {
   return &children;
+}
+
+glm::mat4& SceneNode::getWorldMatrix(void)
+{
+  return worldMatrix;
 }

--- a/src/SceneNode.h
+++ b/src/SceneNode.h
@@ -3,10 +3,11 @@
 
 #include <vector>
 
-#include "GameObject.h"
 #include "Shader.h"
 
 #include "Transform.h"
+
+class GameObject;
 
 class SceneNode
 {
@@ -19,11 +20,12 @@ public:
 
   void updateAll(int delta);
   void renderAll(Shader *shader);
-  void render(Shader *shader);
 
   Transform& getTransform(void);
 
   std::vector<SceneNode*> *getChildren(void);
+
+  glm::mat4& getWorldMatrix(void);
 private:
   Transform transform;
 
@@ -31,6 +33,8 @@ private:
 
   std::vector<SceneNode*> children;
   std::vector<GameObject*> gameObjects;
+
+  glm::mat4 worldMatrix;
 };
 
 #endif

--- a/src/VisibleObject.cpp
+++ b/src/VisibleObject.cpp
@@ -18,6 +18,8 @@ void VisibleObject::update(int delta)
 void VisibleObject::render(Shader *shader)
 {
   shader->bind();
+  glUniformMatrix4fv(shader->getUniformLocation("Model"), 1, GL_FALSE, &(parentNode->getWorldMatrix())[0][0]);
+
   texture->bind(0);
   mesh->render();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,8 +32,6 @@ void CoolGame::render(GLManager *glManager)
 
 void CoolGame::update(int delta, KeyboardHandler *keyboardHandler)
 {
-  Game::update(delta, keyboardHandler);
-
   static float rr = 0;
   rr += delta * 0.005;
   moneyHead->getTransform().setPosition(glm::vec3(glm::sin(rr), 0, 0));
@@ -62,6 +60,8 @@ void CoolGame::update(int delta, KeyboardHandler *keyboardHandler)
   if (keyboardHandler->isReleased(SDLK_LEFT) && keyboardHandler->isReleased(SDLK_RIGHT)) {
     primary_camera->moveX(0.0f);
   }
+  
+  Game::update(delta, keyboardHandler);
 }
 
 void CoolGame::init(void)


### PR DESCRIPTION
Unfortunately the implementation I had for hierarchical
transformations in the scene graph wouldn't work in some
cases, (e.g. where I want a camera game object to
know its world co-ordinates). So because of this
I have gone back to computing the world matrix in 
the scene graph. This feels ugly.. But maybe its okay!
